### PR TITLE
Use 'key' kwarg in min/max/sorted when calculating with dicts

### DIFF
--- a/src/1/calculating_with_dictionaries/example.py
+++ b/src/1/calculating_with_dictionaries/example.py
@@ -1,6 +1,7 @@
 # example.py
 #
 # Example of calculating with dictionaries
+from operator import itemgetter
 
 prices = {
    'ACME': 45.23,
@@ -11,15 +12,15 @@ prices = {
 }
 
 # Find min and max price
-min_price = min(zip(prices.values(), prices.keys()))
-max_price = max(zip(prices.values(), prices.keys()))
+min_price = min(prices.items(), key=itemgetter(1))
+max_price = max(prices.items(), key=itemgetter(1))
 
 print('min price:', min_price)
 print('max price:', max_price)
 
 print('sorted prices:')
-prices_sorted = sorted(zip(prices.values(), prices.keys()))
-for price, name in prices_sorted:
+prices_sorted = sorted(prices.items(), key=itemgetter(1))
+for name, price in prices_sorted:
     print('    ', name, price)
 
 


### PR DESCRIPTION
Instead of zipping the values and keys of a dictionary to
sort or find the min/max, why not use the 'key' kwarg of those 
functions along with dict.items()?
