### PR TITLE
Update example.py

### DIFF
--- a/src/4/how_to_flatten_a_nested_sequence/example.py
+++ b/src/4/how_to_flatten_a_nested_sequence/example.py
@@ -5,14 +5,14 @@ from collections import Iterable
 def flatten(items, ignore_types=(str, bytes)):
     for x in items:
         if isinstance(x, Iterable) and not isinstance(x, ignore_types):
-            yield from flatten(x)
+            yield from flatten(x, ignore_types)
         else:
             yield x
 
-items = [1, 2, [3, 4, [5, 6], 7], 8]
+items = [1, 2, [3, 4, (5, 6), 7], 8]
 
 # Produces 1 2 3 4 5 6 7 8
-for x in flatten(items):
+for x in flatten(items, ignore_types=tuple):
     print(x)
 
 items = ['Dave', 'Paula', ['Thomas', 'Lewis']]


### PR DESCRIPTION
If the ignore_types is tuple instead of default (str, bytes), need add ignore_types argument when calling flatten() recursively.