### PR TITLE
docs: fix simple typo, correponding -> corresponding

### DIFF
--- a/src/12/defining_an_actor_task/tagged.py
+++ b/src/12/defining_an_actor_task/tagged.py
@@ -6,7 +6,7 @@ class TaggedActor(Actor):
              tag, *payload = self.recv()
              getattr(self,"do_"+tag)(*payload)
     
-    # Methods correponding to different message tags
+    # Methods corresponding to different message tags
     def do_A(self, x):
         print("Running A", x)
 


### PR DESCRIPTION
There is a small typo in src/12/defining_an_actor_task/tagged.py.

Should read `corresponding` rather than `correponding`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md